### PR TITLE
Update TraktAirs model

### DIFF
--- a/lib/src/commonMain/kotlin/app/moviebase/trakt/model/TraktShowsModel.kt
+++ b/lib/src/commonMain/kotlin/app/moviebase/trakt/model/TraktShowsModel.kt
@@ -26,9 +26,9 @@ data class TraktShow(
 
 @Serializable
 data class TraktAirs(
-    @SerialName("day") val day: String,
-    @SerialName("time") val time: String,
-    @SerialName("timezone") val timezone: String,
+    @SerialName("day") val day: String? = null,
+    @SerialName("time") val time: String? = null,
+    @SerialName("timezone") val timezone: String? = null,
 )
 
 @Serializable


### PR DESCRIPTION
None of the properties are guaranteed to be present, so we need to mark them as nullable.

I found this out from expections thrown and logged in Crashlytics.