### PR TITLE
Add retry for HTTP errors such as 429

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ***Track and discover your TV shows and movies with Trakt.***
 
-[![Maven Central](https://img.shields.io/maven-central/v/app.moviebase/trakt-kotlin?label=Maven%20Central)](https://central.sonatype.com/artifact/app.moviebase/trakt-api/)
+[![Maven Central](https://img.shields.io/maven-central/v/app.moviebase/trakt-api?label=Maven%20Central)](https://central.sonatype.com/artifact/app.moviebase/trakt-api/)
 ![Github Actions](https://github.com/MoviebaseApp/trakt-kotlin/actions/workflows/build.yml/badge.svg)
 [![Issues](https://img.shields.io/github/issues/MoviebaseApp/trakt-kotlin)](https://github.com/MoviebaseApp/tmdb-api/issues)
 [![Kotlin](https://img.shields.io/badge/kotlin-1.8.10-blue.svg?logo=kotlin)](http://kotlinlang.org)

--- a/lib/src/commonMain/kotlin/app/moviebase/trakt/TraktClientConfig.kt
+++ b/lib/src/commonMain/kotlin/app/moviebase/trakt/TraktClientConfig.kt
@@ -18,7 +18,7 @@ class TraktClientConfig {
     var expectSuccess: Boolean = true
     var useCache: Boolean = false
     var useTimeout: Boolean = false
-    var maxRetriesOnException: Int? = null
+    var maxRetries: Int = 3
 
     internal var httpClientConfigBlock: (HttpClientConfig<*>.() -> Unit)? = null
     internal var httpClientBuilder: (() -> HttpClient)? = null

--- a/lib/src/jvmTest/kotlin/app/moviebase/trakt/TraktRateLimitTest.kt
+++ b/lib/src/jvmTest/kotlin/app/moviebase/trakt/TraktRateLimitTest.kt
@@ -1,0 +1,90 @@
+package app.moviebase.trakt
+
+import app.moviebase.trakt.core.JsonFactory
+import app.moviebase.trakt.model.TraktShow
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlin.system.measureTimeMillis
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import org.junit.jupiter.api.Test
+
+class TraktRateLimitTest {
+
+    val result = TraktShow(title = "Vikings")
+    val show = JsonFactory.create().encodeToString(result)
+
+    @Test
+    fun `it can fetches with one retry of one second`() = runBlocking {
+        val config = mockHttpErrorConfig(
+            result = show,
+            retryAfterSeconds = 1
+        )
+        val client = Trakt(config)
+
+        val timeInMillis = measureTimeMillis {
+            val traktShow = client.shows.getSummary("vikings", TraktExtended.FULL)
+            assertThat(traktShow.title).isEqualTo("Vikings")
+        }
+
+        assertThat(timeInMillis).isGreaterThan(1000L)
+    }
+
+    @Test
+    fun `it can fetches with three retries and without delays`() = runTest {
+        val config = mockHttpErrorConfig(
+            result = show,
+            timesToFail = 3,
+            retryAfterSeconds = 1
+        )
+        val client = Trakt(config)
+
+        val traktShow = client.shows.getSummary("vikings", TraktExtended.FULL)
+        assertThat(traktShow.title).isEqualTo("Vikings")
+    }
+
+    private fun mockHttpErrorConfig(
+        result: String,
+        timesToFail: Int = 1,
+        retryAfterSeconds: Int = 1
+    ): TraktClientConfig.() -> Unit = {
+        traktApiKey = "someKey"
+        useCache = true
+        useTimeout = true
+
+        maxRetries = 3
+
+        var times = timesToFail
+
+        httpClient(MockEngine) {
+            logging {
+                logger = TestLogger()
+                level = LogLevel.HEADERS
+            }
+
+            engine {
+                addHandler { _ ->
+                    if(times > 0) {
+                        val headers = headersOf(
+                            "Content-Type" to listOf(ContentType.Application.Json.toString()),
+                            "X-Ratelimit" to listOf("""{"name":"UNAUTHED_API_GET_LIMIT","period":300,"limit":1000,"remaining":0,"until":"2020-10-10T00:24:00Z"}"""),
+                            "Retry-After" to listOf(retryAfterSeconds.toString()) // after 1 seconds
+                        )
+                        times--
+                        respondError(HttpStatusCode.TooManyRequests, headers = headers)
+                    } else {
+                        val headers = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
+                        respond(content = result, headers = headers)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/lib/src/jvmTest/kotlin/app/moviebase/trakt/TraktRateLimitTest.kt
+++ b/lib/src/jvmTest/kotlin/app/moviebase/trakt/TraktRateLimitTest.kt
@@ -25,7 +25,7 @@ class TraktRateLimitTest {
     fun `it can fetches with one retry of one second`() = runBlocking {
         val config = mockHttpErrorConfig(
             result = show,
-            retryAfterSeconds = 1
+            retryAfterSeconds = 1,
         )
         val client = Trakt(config)
 
@@ -42,7 +42,7 @@ class TraktRateLimitTest {
         val config = mockHttpErrorConfig(
             result = show,
             timesToFail = 3,
-            retryAfterSeconds = 1
+            retryAfterSeconds = 1,
         )
         val client = Trakt(config)
 
@@ -53,7 +53,7 @@ class TraktRateLimitTest {
     private fun mockHttpErrorConfig(
         result: String,
         timesToFail: Int = 1,
-        retryAfterSeconds: Int = 1
+        retryAfterSeconds: Int = 1,
     ): TraktClientConfig.() -> Unit = {
         traktApiKey = "someKey"
         useCache = true
@@ -71,11 +71,11 @@ class TraktRateLimitTest {
 
             engine {
                 addHandler { _ ->
-                    if(times > 0) {
+                    if (times > 0) {
                         val headers = headersOf(
                             "Content-Type" to listOf(ContentType.Application.Json.toString()),
                             "X-Ratelimit" to listOf("""{"name":"UNAUTHED_API_GET_LIMIT","period":300,"limit":1000,"remaining":0,"until":"2020-10-10T00:24:00Z"}"""),
-                            "Retry-After" to listOf(retryAfterSeconds.toString()) // after 1 seconds
+                            "Retry-After" to listOf(retryAfterSeconds.toString()), // after 1 seconds
                         )
                         times--
                         respondError(HttpStatusCode.TooManyRequests, headers = headers)

--- a/lib/src/jvmTest/kotlin/app/moviebase/trakt/TraktTestEnvironment.kt
+++ b/lib/src/jvmTest/kotlin/app/moviebase/trakt/TraktTestEnvironment.kt
@@ -43,7 +43,7 @@ fun defaultTraktConfiguration(
 
     useCache = true
     useTimeout = true
-    maxRetriesOnException = 3
+    maxRetries = 3
 
     httpClient(OkHttp) {
         logging {

--- a/lib/src/jvmTest/kotlin/app/moviebase/trakt/core/HttpClientTest.kt
+++ b/lib/src/jvmTest/kotlin/app/moviebase/trakt/core/HttpClientTest.kt
@@ -1,5 +1,3 @@
-// ktlint-disable filename
-
 package app.moviebase.trakt.core
 
 import app.moviebase.trakt.TraktWebConfig


### PR DESCRIPTION
Retry on a few HTTP errors. Ktor calculates the delay based on the Retry-After in the header.

Related to #43 