### PR TITLE
Make HttpClient public

### DIFF
--- a/lib/src/commonMain/kotlin/app/moviebase/trakt/Trakt.kt
+++ b/lib/src/commonMain/kotlin/app/moviebase/trakt/Trakt.kt
@@ -27,10 +27,12 @@ class Trakt internal constructor(private val config: TraktClientConfig) {
 
     constructor(traktApiKey: String) : this(TraktClientConfig.withKey(traktApiKey))
 
-    private val client: HttpClient = HttpClientFactory.create(config).apply {
-        interceptRequest {
-            it.header(TraktHeader.API_KEY, config.traktApiKey)
-            it.header(TraktHeader.API_VERSION, TraktWebConfig.VERSION)
+    val client: HttpClient by lazy {
+        HttpClientFactory.create(config).apply {
+            interceptRequest {
+                it.header(TraktHeader.API_KEY, config.traktApiKey)
+                it.header(TraktHeader.API_VERSION, TraktWebConfig.VERSION)
+            }
         }
     }
 


### PR DESCRIPTION
There's no real reason to hide it, as it stops calling being able to customize or tweak the client later.

Also made it lazily instantiated.